### PR TITLE
import utils in init file

### DIFF
--- a/src/astrodb_scripts/__init__.py
+++ b/src/astrodb_scripts/__init__.py
@@ -1,0 +1,1 @@
+from utils import *


### PR DESCRIPTION
Addresses what we talked about in co-working — this way, we can import 

`from astrodb_scripts import *`

as opposed to

`from astrodb_scripts.utils import *`

Addresses #5.

 